### PR TITLE
Fix git clone url in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 
 ### To clone this repository:
 ```
-git clone https://github.com/LawranceLiu/Azure-Sphere-MT3620-M4-Samples.git
+git clone https://github.com/MediaTek-Labs/mt3620_m4_software.git
 ```
 
 ### Description


### PR DESCRIPTION
Moved the URL from a personal repository to the corporate one.